### PR TITLE
[feat] member, oauth, category의 기본적인 예외 처리

### DIFF
--- a/be/src/main/java/kr/codesquad/secondhand/api/category/domain/Category.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/domain/Category.java
@@ -3,6 +3,7 @@ package kr.codesquad.secondhand.api.category.domain;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import kr.codesquad.secondhand.api.category.exception.InvalidCategoryIdException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -52,6 +53,6 @@ public enum Category {
         return Arrays.stream(values())
                 .filter(category -> category.id.equals(categoryId))
                 .findAny()
-                .orElseThrow();
+                .orElseThrow(InvalidCategoryIdException::new);
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/exception/CategoryException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/exception/CategoryException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.category.exception;
+
+import kr.codesquad.secondhand.global.exception.CustomException;
+
+public class CategoryException extends CustomException {
+
+    public CategoryException(String message) {
+        super(message);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/exception/InvalidCategoryIdException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/exception/InvalidCategoryIdException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.category.exception;
+
+public class InvalidCategoryIdException extends CategoryException {
+
+    private static final String ERROR_MESSAGE = "존재하지 않는 카테고리 Id 입니다.";
+
+    public InvalidCategoryIdException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/exception/InvalidCategoryIdException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/exception/InvalidCategoryIdException.java
@@ -2,7 +2,7 @@ package kr.codesquad.secondhand.api.category.exception;
 
 public class InvalidCategoryIdException extends CategoryException {
 
-    private static final String ERROR_MESSAGE = "존재하지 않는 카테고리 Id 입니다.";
+    private static final String ERROR_MESSAGE = "존재하지 않는 Category Id 입니다.";
 
     public InvalidCategoryIdException() {
         super(ERROR_MESSAGE);

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/exception/InvalidMemberAddressIdException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/exception/InvalidMemberAddressIdException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.member.exception;
+
+public class InvalidMemberAddressIdException extends MemberAddressException {
+
+    private static final String ERROR_MESSAGE = "회원 정보에 없는 Address Id 이거나 존재하지 않는 Address Id 입니다. ";
+
+    public InvalidMemberAddressIdException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/exception/MemberAddressException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/exception/MemberAddressException.java
@@ -1,0 +1,14 @@
+package kr.codesquad.secondhand.api.member.exception;
+
+public class MemberAddressException extends MemberException {
+
+    private static final String ERROR_MESSAGE = "존재하지 않는 Address Id 입니다.";
+
+    public MemberAddressException() {
+        super(ERROR_MESSAGE);
+    }
+
+    public MemberAddressException(String message) {
+        super(message);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/exception/MemberException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.member.exception;
+
+import kr.codesquad.secondhand.global.exception.CustomException;
+
+public class MemberException extends CustomException {
+
+    public MemberException(String message) {
+        super(message);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberAddressService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberAddressService.java
@@ -5,6 +5,7 @@ import kr.codesquad.secondhand.api.address.domain.Address;
 import kr.codesquad.secondhand.api.member.domain.Member;
 import kr.codesquad.secondhand.api.member.domain.MemberAddress;
 import kr.codesquad.secondhand.api.member.dto.response.MemberAddressResponse;
+import kr.codesquad.secondhand.api.member.exception.InvalidMemberAddressIdException;
 import kr.codesquad.secondhand.api.member.repository.MemberAddressRepositoryImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,12 +42,13 @@ public class MemberAddressService {
 
     private void resetLastVisitedAddress(Long memberId) {
         MemberAddress memberAddress = memberAddressRepository.findByMemberIdAndIsLastVisited(memberId, true)
-                .orElseThrow();
+                .orElseThrow(); // TODO: 무슨 예외를 날려야할지 고민중
         memberAddress.updateLastVisited(false);
     }
 
     private void setLastVisitedAddress(Long lastVisitedAddressId) {
-        MemberAddress lastVisitedAddress = memberAddressRepository.findByAddressId(lastVisitedAddressId).orElseThrow();
+        MemberAddress lastVisitedAddress = memberAddressRepository.findByAddressId(lastVisitedAddressId)
+                .orElseThrow(InvalidMemberAddressIdException::new);
         lastVisitedAddress.updateLastVisited(true);
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthAttributes.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthAttributes.java
@@ -2,6 +2,7 @@ package kr.codesquad.secondhand.api.oauth.domain;
 
 import java.util.Arrays;
 import java.util.Map;
+import kr.codesquad.secondhand.api.oauth.exception.InvalidOauthProviderNameException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -46,7 +47,7 @@ public enum OAuthAttributes {
         return Arrays.stream(values())
                 .filter(oAuthAttribute -> oAuthAttribute.providerName.equals(providerName))
                 .findAny()
-                .orElseThrow();
+                .orElseThrow(InvalidOauthProviderNameException::new);
     }
 
     public abstract OAuthProfile of(Map<String, Object> attributes);

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthProfile.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/domain/OAuthProfile.java
@@ -3,6 +3,7 @@ package kr.codesquad.secondhand.api.oauth.domain;
 import java.util.Arrays;
 import java.util.Map;
 import kr.codesquad.secondhand.api.member.domain.Member;
+import kr.codesquad.secondhand.api.oauth.exception.InvalidOauthProviderNameException;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -27,7 +28,7 @@ public class OAuthProfile {
         return Arrays.stream(OAuthAttributes.values())
                 .filter(provider -> providerName.equals(provider.providerName))
                 .findFirst()
-                .orElseThrow() // TODO: 예외처리
+                .orElseThrow(InvalidOauthProviderNameException::new)
                 .of(attributes);
     }
 

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/exception/InvalidOauthProviderNameException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/exception/InvalidOauthProviderNameException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.oauth.exception;
+
+public class InvalidOauthProviderNameException extends OAuthException {
+
+    private static final String ERROR_MESSAGE = "존재하지 않는 Oauth Provider 입니다.";
+
+    public InvalidOauthProviderNameException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/oauth/exception/OAuthException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/oauth/exception/OAuthException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.oauth.exception;
+
+import kr.codesquad.secondhand.global.exception.CustomException;
+
+public class OAuthException extends CustomException {
+
+    public OAuthException(String message) {
+        super(message);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/global/exception/CustomException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/exception/CustomException.java
@@ -1,0 +1,11 @@
+package kr.codesquad.secondhand.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    public CustomException(String message) {
+        super(message);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/global/exception/ErrorResponseEntity.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/exception/ErrorResponseEntity.java
@@ -1,0 +1,13 @@
+package kr.codesquad.secondhand.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponseEntity {
+
+    private final String message;
+
+    public ErrorResponseEntity(String message) {
+        this.message = "[ERROR] " + message;
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/global/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package kr.codesquad.secondhand.global.exception;
 
 import kr.codesquad.secondhand.api.category.exception.CategoryException;
+import kr.codesquad.secondhand.api.member.exception.MemberException;
+import kr.codesquad.secondhand.api.oauth.exception.OAuthException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,6 +28,22 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage());
         e.printStackTrace();
         return new ErrorResponseEntity("Oauth 서버 관련 오류입니다.");
+    }
+
+    @ExceptionHandler(MemberException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponseEntity handleMemberException(MemberException e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ErrorResponseEntity(e.getMessage());
+    }
+
+    @ExceptionHandler(OAuthException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponseEntity handleOauthException(OAuthException e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ErrorResponseEntity(e.getMessage());
     }
 
     @ExceptionHandler(CategoryException.class)

--- a/be/src/main/java/kr/codesquad/secondhand/global/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.reactive.function.client.WebClientException;
 
 @Slf4j
 @RestControllerAdvice
@@ -16,7 +17,15 @@ public class GlobalExceptionHandler {
     public ErrorResponseEntity handleException(Exception e) {
         log.error(e.getMessage());
         e.printStackTrace();
-        return new ErrorResponseEntity("[ERROR] 서버 오류입니다.");
+        return new ErrorResponseEntity("서버 오류입니다.");
+    }
+
+    @ExceptionHandler(WebClientException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponseEntity handleWebClientException(WebClientException e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ErrorResponseEntity("Oauth 서버 관련 오류입니다.");
     }
 
     @ExceptionHandler(CategoryException.class)

--- a/be/src/main/java/kr/codesquad/secondhand/global/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package kr.codesquad.secondhand.global.exception;
+
+import kr.codesquad.secondhand.api.category.exception.CategoryException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponseEntity handleException(Exception e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ErrorResponseEntity("[ERROR] 서버 오류입니다.");
+    }
+
+    @ExceptionHandler(CategoryException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponseEntity handleCategoryException(CategoryException e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ErrorResponseEntity(e.getMessage());
+    }
+
+}


### PR DESCRIPTION
## 🔑 Key changes
- #52 
- Member 예외 처리
  - [X] 회원 정보에 없는 address Id로 요청이 올 경우
  - [X] 존재하지 않는 address Id일 경우
- Oauth 예외 처리
  - [X] Provider Name이 유효하지 않을 경우
  - [X] Oauth 서버로부터 유효한 응답을 받지 않았을 경우
- Category 예외 처리
  - [X] 유효하지 않은 Category Id일 경우

## 👋 To reviewers
기본적인 예외 처리만 했어요.
나중에 좀 더 꼼꼼히 처리해야 할듯 합니다.

예외 응답 구조도 일단 임의로 구현했는데,
내일 같이 얘기해서 fix해요!

## ✔️ Completed Issue Number
close #52 