### PR TITLE
[feat] request dto 유효성 검증 기능 구현

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	// Jasypt
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
@@ -46,6 +45,9 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/controller/MemberController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/controller/MemberController.java
@@ -15,6 +15,7 @@ import kr.codesquad.secondhand.api.member.service.MemberFacadeService;
 import kr.codesquad.secondhand.api.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,7 +37,7 @@ public class MemberController {
      */
     @PostMapping("/api/members/sign-in/{provider}")
     public ResponseEntity<OAuthSignInResponse> login(@PathVariable String provider,
-                                                     @RequestBody OAuthSignInRequest request) {
+                                                     @Validated @RequestBody OAuthSignInRequest request) {
 
         OAuthSignInResponse oAuthSignInResponse = memberFacadeService.login(provider, request.getAccessCode());
         return ResponseEntity.ok()
@@ -45,7 +46,7 @@ public class MemberController {
 
     @PutMapping("/api/members/addresses")
     public ResponseEntity<List<MemberAddressResponse>> updateMemberAddresses(HttpServletRequest httpServletRequest,
-                                                                             @RequestBody MemberAddressUpdateRequest memberAddressUpdateRequest) {
+                                                                             @Validated @RequestBody MemberAddressUpdateRequest memberAddressUpdateRequest) {
         Long memberId = extractMemberId(httpServletRequest);
         List<MemberAddressResponse> memberAddressResponses = memberFacadeService.updateMemberAddresses(
                 memberId,

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/dto/request/MemberAddressUpdateRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/dto/request/MemberAddressUpdateRequest.java
@@ -1,11 +1,13 @@
 package kr.codesquad.secondhand.api.member.dto.request;
 
 import java.util.List;
+import javax.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class MemberAddressUpdateRequest {
 
+    @Size(min = 1, max = 2, message = "동네 정보는 최소 1개, 최대 2개로 설정해야 합니다.")
     private List<Long> addressIds;
 
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/dto/request/OAuthSignInRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/dto/request/OAuthSignInRequest.java
@@ -1,10 +1,11 @@
 package kr.codesquad.secondhand.api.member.dto.request;
 
+import javax.validation.constraints.NotEmpty;
 import lombok.Getter;
 
 @Getter
 public class OAuthSignInRequest {
 
-    // Oauth 서버 인증용 Authorization Code
+    @NotEmpty
     private String accessCode;
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/controller/ProductController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/controller/ProductController.java
@@ -13,6 +13,7 @@ import kr.codesquad.secondhand.api.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -31,7 +32,7 @@ public class ProductController {
 
     @PostMapping("/api/products")
     public ResponseEntity<ProductCreateResponse> createProduct(HttpServletRequest httpServletRequest,
-                                                               @ModelAttribute ProductCreateRequest productCreateRequest) {
+                                                               @Validated @ModelAttribute ProductCreateRequest productCreateRequest) {
         Long memberId = extractMemberId(httpServletRequest);
         ProductCreateResponse productCreateResponse = productFacadeService.saveProduct(memberId, productCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -49,7 +50,7 @@ public class ProductController {
 
     @PatchMapping("/api/products/{productId}")
     public ResponseEntity<String> updateProduct(@PathVariable Long productId,
-                                                @ModelAttribute ProductUpdateRequest productUpdateRequest) {
+                                                @Validated @ModelAttribute ProductUpdateRequest productUpdateRequest) {
         productFacadeService.updateProduct(productId, productUpdateRequest);
         return ResponseEntity.ok()
                 .build();
@@ -57,7 +58,7 @@ public class ProductController {
 
     @PatchMapping("/api/products/{productId}/status")
     public ResponseEntity<String> updateProductStatus(@PathVariable Long productId,
-                                                      @RequestBody ProductStatusUpdateRequest request) {
+                                                      @Validated @RequestBody ProductStatusUpdateRequest request) {
         productService.updateProductStatus(productId, request);
         return ResponseEntity.ok()
                 .build();

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductCreateRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductCreateRequest.java
@@ -2,6 +2,8 @@ package kr.codesquad.secondhand.api.product.dto;
 
 import java.net.URL;
 import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import kr.codesquad.secondhand.api.address.domain.Address;
 import kr.codesquad.secondhand.api.category.domain.Category;
 import kr.codesquad.secondhand.api.member.domain.Member;
@@ -14,11 +16,24 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class ProductCreateRequest {
 
+    @NotNull(message = "등록할 상품의 카테고리 정보가 비어 있습니다.")
     private final Long categoryId;
+
+    @NotNull(message = "등록할 상품의 동네 정보가 비어 있습니다.")
     private final Long addressId;
+
+    @NotBlank(message = "제목이 비어있습니다.")
     private final String title;
+
+    @NotBlank(message = "내용이 비어있습니다.")
     private final String content;
+
     private final Long price;
+
+    // TODO Multipart는 Bean Validation이 안먹혀서 Spring이 제공하는 다른 방법이 있는지 확인 필요, 아님 직접 검증하는 코드 구현
+//    @Valid
+//    @NotEmpty(message = "상품 이미지는 최소 1개를 첨부해야 합니다.")
+//    @Size(min = 1, max = 10, message = "상품 이미지는 최소 1개를 첨부해야 하며, 최대 10개까지 첨부할 수 있습니다.")
     private final List<MultipartFile> images;
 
     public Product toEntity(Member seller, Integer statusId, Address address, Category category, URL thumbnailImgUrl) {

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductStatusUpdateRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductStatusUpdateRequest.java
@@ -1,10 +1,12 @@
 package kr.codesquad.secondhand.api.product.dto;
 
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class ProductStatusUpdateRequest {
 
+    @NotNull(message = "업데이트할 상품 상태 정보가 없습니다.")
     private Integer statusId;
 
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductUpdateRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductUpdateRequest.java
@@ -1,17 +1,28 @@
 package kr.codesquad.secondhand.api.product.dto;
 
 import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 public class ProductUpdateRequest {
 
+    @NotNull(message = "등록할 상품의 카테고리 정보가 비어 있습니다.")
     private final Long categoryId;
+
+    @NotNull(message = "등록할 상품의 동네 정보가 비어 있습니다.")
     private final Long addressId;
+
+    @NotEmpty(message = "제목이 비어있습니다.")
     private final String title;
+
+    @NotEmpty(message = "내용이 비어있습니다.")
     private final String content;
+
     private final Long price;
+    // TODO Multipart는 Bean Validation이 안먹혀서 Spring이 제공하는 다른 방법이 있는지 확인 필요, 아님 직접 검증하는 코드 구현
     private final List<MultipartFile> newImages;
     private final List<Long> deletedImgIds;
 

--- a/be/src/main/java/kr/codesquad/secondhand/global/exception/ErrorResponseEntity.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/exception/ErrorResponseEntity.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.global.exception;
 
+import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -9,5 +10,9 @@ public class ErrorResponseEntity {
 
     public ErrorResponseEntity(String message) {
         this.message = "[ERROR] " + message;
+    }
+
+    public ErrorResponseEntity(List<String> messages) {
+        this.message = "[ERROR] " + String.join("; ", messages);
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/global/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,15 @@
 package kr.codesquad.secondhand.global.exception;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import kr.codesquad.secondhand.api.category.exception.CategoryException;
 import kr.codesquad.secondhand.api.member.exception.MemberException;
 import kr.codesquad.secondhand.api.oauth.exception.OAuthException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -28,6 +33,21 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage());
         e.printStackTrace();
         return new ErrorResponseEntity("Oauth 서버 관련 오류입니다.");
+    }
+
+    @ExceptionHandler(BindException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponseEntity handleBindException(BindException e) {
+        log.error(e.getMessage());
+        e.printStackTrace();
+        return new ErrorResponseEntity(getFieldErrorMessages(e.getBindingResult()));
+    }
+
+    private List<String> getFieldErrorMessages(BindingResult bindingResult) {
+        return bindingResult.getFieldErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
     }
 
     @ExceptionHandler(MemberException.class)


### PR DESCRIPTION
## 🔑 Key changes
- #82 

## 👋 To reviewers
- 이전 PR이 머지가 되지 않아서 이전 커밋이 있는데 머지 후 다시 PR 올리겠습니다.
- 우선 Request Dto 에만 인증 로직을 추가하였는데, Entity 에도 인증 로직이 필요할 듯 싶습니다.
  - 다만 Entity의 경우 상황에 따라 검증 로직이 다를 수 있는데(예를 들어 R일 경우 id가 있지만, C일 경우 id가 없음) 관련하여 어떻게 유효성 검증을 할지 논의가 필요합니다.
- 또 상품 delete이랑 update와 같이 memberId 정보가 없어도 수정/삭제가 가능한 경우, 실제 해당 멤버의 상품인지 검증하는 로직이 있어야 할 듯 합니다. 관련해서도 논의가 필요합니다. 
- `Multipart`의 경우 `Bean Validation`이 적용되지 않습니다. 검증할 수 있는 로직 관련해서 논의가 필요합니다.

## ✔️ Completed Issue Number
close #82
