### PR TITLE
[feat] 로그아웃 기능 구현

### DIFF
--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/MemberRefreshToken.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/MemberRefreshToken.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.api.jwt.domain;
 
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
@@ -20,4 +21,7 @@ public class MemberRefreshToken {
 
     private String refreshToken;
 
+    public boolean matches(String refreshToken) {
+        return Objects.equals(this.refreshToken, refreshToken);
+    }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/exception/BlackListedAccessTokenException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/exception/BlackListedAccessTokenException.java
@@ -1,0 +1,12 @@
+package kr.codesquad.secondhand.api.jwt.exception;
+
+import io.jsonwebtoken.JwtException;
+
+public class BlackListedAccessTokenException extends JwtException {
+
+    public static final String ERROR_MESSAGE = "로그아웃한 사용자입니다.";
+
+    public BlackListedAccessTokenException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/exception/JwtExceptionType.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/exception/JwtExceptionType.java
@@ -17,7 +17,8 @@ public enum JwtExceptionType {
     EXPIRED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, ExpiredJwtException.class, "토큰 기한이 만료되었습니다."),
     MALFORMED_JWT_EXCEPTION(HttpStatus.UNAUTHORIZED, MalformedJwtException.class, "잘못된 형식의 토큰입니다."),
     SIGNATURE_EXCEPTION(HttpStatus.UNAUTHORIZED, SignatureException.class, "JWT 서명 검증에 실패했습니다."),
-    TOKEN_NOT_FOUND_EXCEPTION(HttpStatus.UNAUTHORIZED, TokenNotFoundException.class, "헤더에 Jwt 토큰이 없습니다.");
+    TOKEN_NOT_FOUND_EXCEPTION(HttpStatus.UNAUTHORIZED, TokenNotFoundException.class, "헤더에 Jwt 토큰이 없습니다."),
+    BLACKLISTED_ACCESS_TOKEN_EXCEPTION(HttpStatus.UNAUTHORIZED, BlackListedAccessTokenException.class, "로그아웃한 사용자입니다.");
 
     private final HttpStatus httpStatus;
     private final Class<? extends RuntimeException> originException;

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/repository/TokenRedisRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/repository/TokenRedisRepository.java
@@ -1,0 +1,23 @@
+package kr.codesquad.secondhand.api.jwt.repository;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TokenRedisRepository {
+
+    private static final String ACCESS_TOKEN_KEY = "accessToken";
+
+    private final RedisTemplate<String, String> template;
+
+    public void addAccessTokenToBlackList(String token, long minutes) {
+        template.opsForValue().set(token, ACCESS_TOKEN_KEY, minutes, TimeUnit.MINUTES);
+    }
+
+    public boolean isAccessTokenInBlackList(String accessToken) {
+        return Boolean.TRUE.equals(template.hasKey(accessToken));
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
@@ -1,8 +1,10 @@
 package kr.codesquad.secondhand.api.jwt.service;
 
 import java.util.Collections;
+import java.util.Date;
 import kr.codesquad.secondhand.api.jwt.domain.Jwt;
 import kr.codesquad.secondhand.api.jwt.domain.MemberRefreshToken;
+import kr.codesquad.secondhand.api.jwt.repository.TokenRedisRepository;
 import kr.codesquad.secondhand.api.jwt.repository.TokenRepository;
 import kr.codesquad.secondhand.api.jwt.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class JwtService {
 
     private static final String MEMBER_ID = "memberId";
+    private static final long BUFFER_TIME_IN_MILLIS = 60 * 1000;
 
     private final JwtProvider jwtProvider;
     private final TokenRepository tokenRepository;
+    private final TokenRedisRepository tokenRedisRepository;
 
     @Transactional
     public Jwt issueJwt(Long memberId) {
@@ -33,4 +37,13 @@ public class JwtService {
         return null;
     }
 
+    public void addAccessTokenToBlackList(String accessToken) {
+        Date expiration = jwtProvider.getExpiration(accessToken);
+        Date currentDate = new Date();
+
+        long ttlMillis = expiration.getTime() - currentDate.getTime(); // TODO 서버 시간과 클라이언트 시간의 불일치 문제 해결 필요
+        long ttlMinutes = (ttlMillis + BUFFER_TIME_IN_MILLIS) / 1000 / 60;
+
+        tokenRedisRepository.addAccessTokenToBlackList(accessToken, ttlMinutes);
+    }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
@@ -7,6 +7,7 @@ import kr.codesquad.secondhand.api.jwt.domain.MemberRefreshToken;
 import kr.codesquad.secondhand.api.jwt.repository.TokenRedisRepository;
 import kr.codesquad.secondhand.api.jwt.repository.TokenRepository;
 import kr.codesquad.secondhand.api.jwt.util.JwtProvider;
+import kr.codesquad.secondhand.api.member.exception.NotSignedInException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,5 +50,9 @@ public class JwtService {
         long ttlMinutes = (ttlMillis + BUFFER_TIME_IN_MILLIS) / 1000 / 60;
 
         tokenRedisRepository.addAccessTokenToBlackList(accessToken, ttlMinutes);
+    }
+
+    public MemberRefreshToken findById(Long memberId) {
+        return tokenRepository.findById(memberId).orElseThrow(NotSignedInException::new);
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
@@ -25,9 +25,7 @@ public class JwtService {
     @Transactional
     public Jwt issueJwt(Long memberId) {
         Jwt jwt = jwtProvider.createTokens(Collections.singletonMap(MEMBER_ID, memberId));
-        if (tokenRepository.existsById(memberId)) {
-            tokenRepository.deleteById(memberId);
-        }
+        deleteRefreshToken(memberId);
         tokenRepository.save(new MemberRefreshToken(memberId, jwt.getRefreshToken()));
         return jwt;
     }
@@ -35,6 +33,12 @@ public class JwtService {
     public String reissueAccessToken() {
         // TODO
         return null;
+    }
+
+    public void deleteRefreshToken(Long memberId) {
+        if (tokenRepository.existsById(memberId)) {
+            tokenRepository.deleteById(memberId);
+        }
     }
 
     public void addAccessTokenToBlackList(String accessToken) {

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/service/JwtService.java
@@ -52,7 +52,9 @@ public class JwtService {
         tokenRedisRepository.addAccessTokenToBlackList(accessToken, ttlMinutes);
     }
 
-    public MemberRefreshToken findById(Long memberId) {
-        return tokenRepository.findById(memberId).orElseThrow(NotSignedInException::new);
+    public boolean isMemberRefreshToken(Long memberId, String refreshToken) {
+        MemberRefreshToken memberRefreshToken = tokenRepository.findById(memberId)
+                .orElseThrow(NotSignedInException::new);
+        return memberRefreshToken.matches(refreshToken);
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/util/JwtProvider.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/util/JwtProvider.java
@@ -61,4 +61,7 @@ public class JwtProvider {
                 .getBody();
     }
 
+    public Date getExpiration(String token) { // TODO Date 타입이 시스템 시간이랑 일치하지 않을 수도 있는데, 관련해서 공부하고 처리 필요
+        return getClaims(token).getExpiration();
+    }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/controller/MemberController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/controller/MemberController.java
@@ -51,7 +51,7 @@ public class MemberController {
                                           @Validated @RequestBody SignOutRequest signOutRequest) {
         Long memberId = extractMemberId(httpServletRequest);
         String accessToken = extractAccessToken(httpServletRequest);
-        memberFacadeService.signOut(memberId, accessToken);
+        memberFacadeService.signOut(memberId, accessToken, signOutRequest.getRefreshToken());
         return ResponseEntity.ok()
                 .build();
     }

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/controller/MemberController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package kr.codesquad.secondhand.api.member.controller;
 
+import static kr.codesquad.secondhand.global.util.HttpAuthorizationUtils.extractAccessToken;
 import static kr.codesquad.secondhand.global.util.HttpAuthorizationUtils.extractMemberId;
 
 import java.util.List;
@@ -7,6 +8,7 @@ import javax.servlet.http.HttpServletRequest;
 import kr.codesquad.secondhand.api.member.dto.request.LastVisitedUpdateRequest;
 import kr.codesquad.secondhand.api.member.dto.request.MemberAddressUpdateRequest;
 import kr.codesquad.secondhand.api.member.dto.request.OAuthSignInRequest;
+import kr.codesquad.secondhand.api.member.dto.request.SignOutRequest;
 import kr.codesquad.secondhand.api.member.dto.response.MemberAddressResponse;
 import kr.codesquad.secondhand.api.member.dto.response.MemberProfileResponse;
 import kr.codesquad.secondhand.api.member.dto.response.OAuthSignInResponse;
@@ -36,12 +38,22 @@ public class MemberController {
      * 로그인 요청
      */
     @PostMapping("/api/members/sign-in/{provider}")
-    public ResponseEntity<OAuthSignInResponse> login(@PathVariable String provider,
-                                                     @Validated @RequestBody OAuthSignInRequest request) {
+    public ResponseEntity<OAuthSignInResponse> signIn(@PathVariable String provider,
+                                                      @Validated @RequestBody OAuthSignInRequest request) {
 
-        OAuthSignInResponse oAuthSignInResponse = memberFacadeService.login(provider, request.getAccessCode());
+        OAuthSignInResponse oAuthSignInResponse = memberFacadeService.signIn(provider, request.getAccessCode());
         return ResponseEntity.ok()
                 .body(oAuthSignInResponse);
+    }
+
+    @PostMapping("/api/sign-out")
+    public ResponseEntity<String> signOut(HttpServletRequest httpServletRequest,
+                                          @Validated @RequestBody SignOutRequest signOutRequest) {
+        Long memberId = extractMemberId(httpServletRequest);
+        String accessToken = extractAccessToken(httpServletRequest);
+        memberFacadeService.signOut(memberId, accessToken);
+        return ResponseEntity.ok()
+                .build();
     }
 
     @PutMapping("/api/members/addresses")

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/dto/request/SignOutRequest.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/dto/request/SignOutRequest.java
@@ -1,0 +1,12 @@
+package kr.codesquad.secondhand.api.member.dto.request;
+
+import javax.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+@Getter
+public class SignOutRequest {
+
+    @NotEmpty(message = "refresh token이 비어있습니다.")
+    private String refreshToken;
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/exception/InvalidRefreshTokenException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.member.exception;
+
+public class InvalidRefreshTokenException extends MemberException {
+
+    private static final String ERROR_MESSAGE = "회원의 Refresh Token 정보와 일치하지 않습니다.";
+
+    public InvalidRefreshTokenException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/exception/NotSignedInException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/exception/NotSignedInException.java
@@ -1,0 +1,10 @@
+package kr.codesquad.secondhand.api.member.exception;
+
+public class NotSignedInException extends MemberException {
+
+    private static final String ERROR_MESSAGE = "로그인하지 않은 사용자입니다.";
+
+    public NotSignedInException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberFacadeService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberFacadeService.java
@@ -25,11 +25,17 @@ public class MemberFacadeService {
     private final AddressService addressService;
 
     @Transactional
-    public OAuthSignInResponse login(String providerName, String authorizationCode) {
+    public OAuthSignInResponse signIn(String providerName, String authorizationCode) {
         OAuthProfile oAuthProfile = oAuthService.requestOauthProfile(providerName, authorizationCode);
         Long memberId = memberService.oAuthLogin(providerName, oAuthProfile);
         Jwt tokens = jwtService.issueJwt(memberId);
         return OAuthSignInResponse.from(tokens);
+    }
+
+    @Transactional
+    public void signOut(Long memberId, String accessToken) {
+        jwtService.deleteRefreshToken(memberId);
+        jwtService.addAccessTokenToBlackList(accessToken);
     }
 
     @Transactional

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberFacadeService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberFacadeService.java
@@ -4,10 +4,12 @@ import java.util.List;
 import kr.codesquad.secondhand.api.address.domain.Address;
 import kr.codesquad.secondhand.api.address.service.AddressService;
 import kr.codesquad.secondhand.api.jwt.domain.Jwt;
+import kr.codesquad.secondhand.api.jwt.domain.MemberRefreshToken;
 import kr.codesquad.secondhand.api.jwt.service.JwtService;
 import kr.codesquad.secondhand.api.member.domain.Member;
 import kr.codesquad.secondhand.api.member.dto.response.MemberAddressResponse;
 import kr.codesquad.secondhand.api.member.dto.response.OAuthSignInResponse;
+import kr.codesquad.secondhand.api.member.exception.InvalidRefreshTokenException;
 import kr.codesquad.secondhand.api.oauth.domain.OAuthProfile;
 import kr.codesquad.secondhand.api.oauth.service.OAuthService;
 import lombok.RequiredArgsConstructor;
@@ -33,9 +35,17 @@ public class MemberFacadeService {
     }
 
     @Transactional
-    public void signOut(Long memberId, String accessToken) {
+    public void signOut(Long memberId, String accessToken, String refreshToken) {
+        if (!isMemberRefreshToken(memberId, refreshToken)) {
+            throw new InvalidRefreshTokenException();
+        }
         jwtService.deleteRefreshToken(memberId);
         jwtService.addAccessTokenToBlackList(accessToken);
+    }
+
+    private boolean isMemberRefreshToken(Long memberId, String refreshToken) { // TODO: 검증 클래스를 별도로 분리할지 고민중
+        MemberRefreshToken memberRefreshToken = jwtService.findById(memberId);
+        return memberRefreshToken.matches(refreshToken);
     }
 
     @Transactional

--- a/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberFacadeService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/member/service/MemberFacadeService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import kr.codesquad.secondhand.api.address.domain.Address;
 import kr.codesquad.secondhand.api.address.service.AddressService;
 import kr.codesquad.secondhand.api.jwt.domain.Jwt;
-import kr.codesquad.secondhand.api.jwt.domain.MemberRefreshToken;
 import kr.codesquad.secondhand.api.jwt.service.JwtService;
 import kr.codesquad.secondhand.api.member.domain.Member;
 import kr.codesquad.secondhand.api.member.dto.response.MemberAddressResponse;
@@ -36,16 +35,11 @@ public class MemberFacadeService {
 
     @Transactional
     public void signOut(Long memberId, String accessToken, String refreshToken) {
-        if (!isMemberRefreshToken(memberId, refreshToken)) {
+        if (!jwtService.isMemberRefreshToken(memberId, refreshToken)) {
             throw new InvalidRefreshTokenException();
         }
         jwtService.deleteRefreshToken(memberId);
         jwtService.addAccessTokenToBlackList(accessToken);
-    }
-
-    private boolean isMemberRefreshToken(Long memberId, String refreshToken) { // TODO: 검증 클래스를 별도로 분리할지 고민중
-        MemberRefreshToken memberRefreshToken = jwtService.findById(memberId);
-        return memberRefreshToken.matches(refreshToken);
     }
 
     @Transactional

--- a/be/src/main/java/kr/codesquad/secondhand/global/config/FilterConfig.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/config/FilterConfig.java
@@ -1,6 +1,7 @@
 package kr.codesquad.secondhand.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.codesquad.secondhand.api.jwt.repository.TokenRedisRepository;
 import kr.codesquad.secondhand.api.jwt.util.JwtProvider;
 import kr.codesquad.secondhand.global.filter.AuthorizationFilter;
 import kr.codesquad.secondhand.global.filter.CorsFilter;
@@ -21,9 +22,10 @@ public class FilterConfig {
 
     @Bean
     public FilterRegistrationBean<AuthorizationFilter> authorizationFilter(JwtProvider jwtProvider,
-                                                                           ObjectMapper objectMapper) {
+                                                                           ObjectMapper objectMapper,
+                                                                           TokenRedisRepository tokenRedisRepository) {
         FilterRegistrationBean<AuthorizationFilter> filterRegistrationBean = new FilterRegistrationBean<>();
-        filterRegistrationBean.setFilter(new AuthorizationFilter(jwtProvider, objectMapper));
+        filterRegistrationBean.setFilter(new AuthorizationFilter(jwtProvider, objectMapper, tokenRedisRepository));
         filterRegistrationBean.setOrder(2);
         return filterRegistrationBean;
     }

--- a/be/src/main/java/kr/codesquad/secondhand/global/util/HttpAuthorizationUtils.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/util/HttpAuthorizationUtils.java
@@ -14,8 +14,8 @@ public class HttpAuthorizationUtils {
         httpServletRequest.setAttribute(MEMBER_ID_CLAIMS_KEY, claims.get(MEMBER_ID_CLAIMS_KEY));
     }
 
-    public static String extractAccessToken(HttpServletRequest request) {
-        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    public static String extractAccessToken(HttpServletRequest httpServletRequest) {
+        String authorizationHeader = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
         return authorizationHeader.substring(BEARER_TOKEN_PREFIX_LENGTH);
     }
 


### PR DESCRIPTION
## 🔑 Key changes
- #88 

## 👋 To reviewers
PR이랑 이슈 내용이 항상 겹치는 것 같아서...
88번 이슈에 구현한 내용 상세하게 적어놨습니다.

처음에 view와 wish처럼 “1::accessToken” 을 키값으로 통일하려고 했습니다.
그런데 연속으로 로그인, 로그아웃을 할 경우, 이전에 블랙리스트에 할당했던 AT이 덮여씌게 되는 이슈가 있습니다.

그래서 List 형태로 저장하는 것을 고려했습니다.
이유는 일부 유저의 정보가 탈취 당했을 경우 해당되는 유저의 토큰을 찾을 수 있기 때문입니다.

다만 List로 저장할 경우 개별 값에 TTL을 설정할 수 없는 이슈가 있습니다.
그래서 다시 원래대로 커밋 revert하고 force push 했습니다.

## ✔️ Completed Issue Number
close #88 
