### PR TITLE
[feat] 상품 목록 조회 환경 구성

### DIFF
--- a/be/src/main/java/kr/codesquad/secondhand/api/product/domain/ProductStats.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/domain/ProductStats.java
@@ -1,0 +1,26 @@
+package kr.codesquad.secondhand.api.product.domain;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ProductStats {
+
+    private static final Integer VIEW_COUNT_INDEX = 0; // 상수화 했어여
+    private static final Integer WISH_COUNT_INDEX = 1;
+
+    private final Integer viewCount;
+    private final Integer wishCount;
+
+    private ProductStats(Integer viewCount, Integer wishCount) {
+        this.viewCount = viewCount;
+        this.wishCount = wishCount;
+    }
+
+    public static ProductStats from(List<Object> stats){
+        Integer viewCount = Integer.parseInt(stats.get(VIEW_COUNT_INDEX).toString());
+        Integer wishCount = Integer.parseInt(stats.get(WISH_COUNT_INDEX).toString());
+        return new ProductStats(viewCount, wishCount);
+    }
+}
+

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/domain/ProductStats.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/domain/ProductStats.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class ProductStats {
 
-    private static final Integer VIEW_COUNT_INDEX = 0; // 상수화 했어여
+    private static final Integer VIEW_COUNT_INDEX = 0;
     private static final Integer WISH_COUNT_INDEX = 1;
 
     private final Integer viewCount;

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductReadResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductReadResponse.java
@@ -9,6 +9,7 @@ import kr.codesquad.secondhand.api.category.domain.Category;
 import kr.codesquad.secondhand.api.category.dto.CategoryReadResponse;
 import kr.codesquad.secondhand.api.product.domain.Product;
 import kr.codesquad.secondhand.api.product.domain.ProductImage;
+import kr.codesquad.secondhand.api.product.domain.ProductStats;
 import kr.codesquad.secondhand.api.product.domain.ProductStatus;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,11 +20,11 @@ public class ProductReadResponse {
     private final Boolean isSeller;
     private final ProductResponse product;
     private final List<ProductImageResponse> images;
-    private final ProductStats stats;
+    private final ProductStatsResponse stats;
     private final List<ProductStatusResponse> statuses;
 
     public ProductReadResponse(Boolean isSeller, ProductResponse product, List<ProductImageResponse> images,
-                               List<ProductStatusResponse> statuses, ProductStats stats) {
+                               List<ProductStatusResponse> statuses, ProductStatsResponse stats) {
         this.isSeller = isSeller;
         this.product = product;
         this.images = images;
@@ -32,20 +33,23 @@ public class ProductReadResponse {
     }
 
     public static ProductReadResponse of(boolean isSeller, Product product, List<ProductImage> productImages,
-                                         List<ProductStatus> productStatuses, List<Integer> stats,
+                                         List<ProductStatus> productStatuses, ProductStats stats,
                                          Category category, Address address) {
         CategoryReadResponse categoryReadResponse = CategoryReadResponse.from(category);
         AddressResponse addressResponse = AddressResponse.from(address);
         ProductResponse productResponse = ProductResponse.from(product, categoryReadResponse, addressResponse);
+
         List<ProductImageResponse> productImageResponse = productImages.stream()
                 .map(ProductImageResponse::from)
                 .collect(Collectors.toUnmodifiableList());
+
         List<ProductStatusResponse> productStatusResponse = productStatuses.stream()
                 .map(ProductStatusResponse::from)
                 .collect(Collectors.toUnmodifiableList());
-        ProductStats productStats = ProductStats.from(stats);
+
+        ProductStatsResponse productStatsResponse = ProductStatsResponse.from(stats);
         return new ProductReadResponse(isSeller, productResponse, productImageResponse, productStatusResponse,
-                productStats);
+                productStatsResponse);
     }
 
     @Getter
@@ -116,22 +120,6 @@ public class ProductReadResponse {
 
         private static ProductStatusResponse from(ProductStatus productStatus) {
             return new ProductStatusResponse(productStatus.getId(), productStatus.getType());
-        }
-    }
-
-    @Getter
-    private static class ProductStats {
-
-        private final Integer viewCount;
-        private final Integer wishCount;
-
-        private ProductStats(Integer viewCount, Integer wishCount) {
-            this.viewCount = viewCount;
-            this.wishCount = wishCount;
-        }
-
-        private static ProductStats from(List<Integer> stats) {
-            return new ProductStats(stats.get(0), stats.get(1));
         }
     }
 

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductSlicesResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductSlicesResponse.java
@@ -21,7 +21,6 @@ public class ProductSlicesResponse {
         this.hasNext = hasNext;
     }
 
-    // 로직은 똑같고 좀 더 가독성 있게 바꿔봤어여, 감귤이 읽기 편한걸로 결정해도 될 듯 합니다.
     public ProductSlicesResponse of(List<Product> products, Map<Long, ProductStats> stats, Boolean hasNext) {
         List<ProductSlice> productSlices = products.stream()
                 .map(product -> {

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductSlicesResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductSlicesResponse.java
@@ -1,0 +1,78 @@
+package kr.codesquad.secondhand.api.product.dto;
+
+import java.net.URL;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.api.product.domain.Product;
+import kr.codesquad.secondhand.api.product.domain.ProductStats;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ProductSlicesResponse {
+
+    private final List<ProductSlice> products;
+    private final Boolean hasNext;
+
+    public ProductSlicesResponse(List<ProductSlice> products, Boolean hasNext) {
+        this.products = products;
+        this.hasNext = hasNext;
+    }
+
+    // 로직은 똑같고 좀 더 가독성 있게 바꿔봤어여, 감귤이 읽기 편한걸로 결정해도 될 듯 합니다.
+    public ProductSlicesResponse of(List<Product> products, Map<Long, ProductStats> stats, Boolean hasNext) {
+        List<ProductSlice> productSlices = products.stream()
+                .map(product -> {
+                    Long productId = product.getId();
+                    ProductStats productStats = stats.get(productId);
+                    return ProductSlice.of(product, productStats);
+                })
+                .collect(Collectors.toUnmodifiableList());
+        return new ProductSlicesResponse(productSlices, hasNext);
+    }
+
+    @Getter
+    private static class ProductSlice {
+
+        private final Long productId;
+        private final Long sellerId;
+        private final URL thumbnailUrl;
+        private final String title;
+        private final String addressName;
+        private final Timestamp createdTime;
+        private final Long price;
+        private final Integer statusId;
+        private final ProductStatsResponse stats;
+
+        @Builder
+        public ProductSlice(Long productId, Long sellerId, URL thumbnailUrl, String title, String addressName,
+                            Timestamp createdTime, Long price, Integer statusId, ProductStatsResponse stats) {
+            this.productId = productId;
+            this.sellerId = sellerId;
+            this.thumbnailUrl = thumbnailUrl;
+            this.title = title;
+            this.addressName = addressName;
+            this.createdTime = createdTime;
+            this.price = price;
+            this.statusId = statusId;
+            this.stats = stats;
+        }
+
+        public static ProductSlice of(Product product, ProductStats stats) {
+            return ProductSlice.builder()
+                    .productId(product.getId())
+                    .sellerId(product.getSeller().getId())
+                    .thumbnailUrl(product.getThumbnailImgUrl())
+                    .title(product.getTitle())
+                    .addressName(product.getAddress().getName())
+                    .createdTime((Timestamp) product.getCreatedTime())
+                    .price(product.getPrice())
+                    .statusId(product.getStatusId())
+                    .stats(ProductStatsResponse.from(stats))
+                    .build();
+        }
+    }
+
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductStatsResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/dto/ProductStatsResponse.java
@@ -1,0 +1,25 @@
+package kr.codesquad.secondhand.api.product.dto;
+
+import kr.codesquad.secondhand.api.product.domain.ProductStats;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ProductStatsResponse {
+
+    private final Integer viewCount;
+    private final Integer wishCount;
+
+    @Builder
+    private ProductStatsResponse(Integer viewCount, Integer wishCount) {
+        this.viewCount = viewCount;
+        this.wishCount = wishCount;
+    }
+
+    public static ProductStatsResponse from(ProductStats stats) {
+        return ProductStatsResponse.builder()
+                .viewCount(stats.getViewCount())
+                .wishCount(stats.getWishCount())
+                .build();
+    }
+}

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/repository/StatRedisRepository.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/repository/StatRedisRepository.java
@@ -1,6 +1,9 @@
 package kr.codesquad.secondhand.api.product.repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import kr.codesquad.secondhand.api.product.domain.ProductStats;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -24,8 +27,17 @@ public class StatRedisRepository {
         redisTemplate.opsForHash().put(key, WISHES_KEY, DEFAULT_COUNT);
     }
 
-    public List<Object> findProductStats(String productId) {
-        return redisTemplate.opsForHash().multiGet(productId, List.of(VIEWS_KEY, WISHES_KEY));
+    public ProductStats findProductStats(String productId) {
+        List<Object> stats = redisTemplate.opsForHash().multiGet(productId, List.of(VIEWS_KEY, WISHES_KEY));
+        return ProductStats.from(stats);
+    }
+
+    public Map<Long, ProductStats> findProductsStats(List<Long> productIds) {
+        return productIds.stream()
+                .collect(Collectors.toUnmodifiableMap(
+                        productId -> productId,
+                        productId -> findProductStats(productId.toString())
+                ));
     }
 
     public void increaseViews(String productKey) {

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/service/ProductFacadeService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/service/ProductFacadeService.java
@@ -9,6 +9,7 @@ import kr.codesquad.secondhand.api.member.domain.Member;
 import kr.codesquad.secondhand.api.member.service.MemberService;
 import kr.codesquad.secondhand.api.product.domain.Product;
 import kr.codesquad.secondhand.api.product.domain.ProductImage;
+import kr.codesquad.secondhand.api.product.domain.ProductStats;
 import kr.codesquad.secondhand.api.product.domain.ProductStatus;
 import kr.codesquad.secondhand.api.product.dto.ProductCreateRequest;
 import kr.codesquad.secondhand.api.product.dto.ProductCreateResponse;
@@ -59,7 +60,7 @@ public class ProductFacadeService {
         boolean isSeller = product.isSellerIdEqualsTo(memberId);
         List<ProductImage> productImages = imageService.findAllByProductId(productId);
         List<ProductStatus> productStatuses = ProductStatus.findAll();
-        List<Integer> stats = statService.findProductStats(memberId, productId);
+        ProductStats stats = statService.findProductStats(memberId, productId);
         Category category = Category.from(product.getCategoryId());
         Address address = product.getAddress();
         return ProductReadResponse.of(isSeller, product, productImages, productStatuses, stats, category, address);

--- a/be/src/main/java/kr/codesquad/secondhand/api/product/service/StatService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/product/service/StatService.java
@@ -1,7 +1,8 @@
 package kr.codesquad.secondhand.api.product.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
+import kr.codesquad.secondhand.api.product.domain.ProductStats;
 import kr.codesquad.secondhand.api.product.repository.StatRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,13 +22,14 @@ public class StatService {
         statRedisRepository.saveNewProductStats(key);
     }
 
-    public List<Integer> findProductStats(Long memberId, Long productId) {
+    public ProductStats findProductStats(Long memberId, Long productId) {
         increaseViews(memberId, productId);
         String productKey = productId.toString();
-        List<Object> stats = statRedisRepository.findProductStats(productKey);
-        return stats.stream()
-                .map(value -> Integer.parseInt(value.toString()))
-                .collect(Collectors.toUnmodifiableList());
+        return statRedisRepository.findProductStats(productKey);
+    }
+
+    public Map<Long, ProductStats> findProductsStats(List<Long> productIds) {
+        return statRedisRepository.findProductsStats(productIds);
     }
 
     @Transactional

--- a/be/src/main/java/kr/codesquad/secondhand/global/filter/AuthorizationFilter.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/filter/AuthorizationFilter.java
@@ -35,7 +35,7 @@ public class AuthorizationFilter implements Filter {
             "/",
             "/api/addresses",
             "/api/categories",
-            "/api/products/*"
+//            "/api/products/*"
     };
 
     private static final String[] POST_WHITE_LIST = new String[]{

--- a/be/src/main/java/kr/codesquad/secondhand/global/filter/AuthorizationFilter.java
+++ b/be/src/main/java/kr/codesquad/secondhand/global/filter/AuthorizationFilter.java
@@ -35,7 +35,7 @@ public class AuthorizationFilter implements Filter {
             "/",
             "/api/addresses",
             "/api/categories",
-//            "/api/products/*"
+//            "/api/products/*" 상세 조회 버그 때문에 수정 필요
     };
 
     private static final String[] POST_WHITE_LIST = new String[]{


### PR DESCRIPTION
## 🔑 Key changes
- [x] ProductStats 도메인 생성 
- [x] ProductReadResponse에서 관리하던 ProductStats 이너 클래스 분리하여 독립적인 Dto로 관리
- [x] 상품목록 조회 시 공용으로 사용 할 ProductSliceResponse DTO구현
- [x] List<String,Object>로 반환하던 레디스 스탯 조회 기능 Repository에서 형변환하여 ProductStats로 반환
- [x] 화이트리스트에서 잠시 products url 제외했습니다.  

## 👋 To reviewers
- 화이트리스트에서 제외한 이유 > GET api/products/* 에 대한 요청이 모두 오픈되어있는데 제품 상세 조회 시 조회수 증가 판단 메소드 때문에 memberId를 사용하고 있는 상황입니다. 그래서 임시로 화이트리스트에서 제거하였습니다. (해결 방안은 ID 대신 IP저장 말곤 생각이 안드네요)

-  redisTemplate<String, ProductStats> 를 사용하지 않은 이유 -> redisTemplate을 사용하여 객체를 저장할 경우 제가 공부한 내용이 맞다면 redistemplate.opsForValue.put(key, ProductStats) 를 통해 저장을 해야할 것으로 예상을 했습니다.

- 이렇게 opsForValue에 객체를 Json 형식으로 저장한다면 조회수 혹은 관심 수를 증가 시킬 때 opsForValue.get(key) 으로 객체를 역직렬화해서 가져온 후 받아온 객체에 조회수 혹은 관심수를 1 올리고 다시 그 객체를 레디스를 저장하게되면 동시성에 문제가 생겨 데이터의 신뢰성을 해칠 수 있다 생각했습니다.

- 동시성 해결을 하기 위한 방안으로는 분산락 걸기, Spring data redis에서 제공하는 increment 를 찾을 수 있었는데
분산락에 비해 redis가 코드 구현의 간편함, 성능에서 뛰어나다 느꼈기에 (내부적으로 동기화하는 redis의 increment에 비해 분산락은 lock을 계속 검증해야하기 때문에 성능이 떨어질 수 밖에 없다 생각함) increment를 사용하고 싶었습니다

- 만약 객체를 opsForValue를 사용한다면 조회 수, 관심 수 필드가 두개인 상황에서 각각의 필드를 구분하여 increment를 사용할 수 없다 생각했습니다 (될지도 모르는데 저는 모르겠어요)
그래서 키 하나에 여러 필드를 관리하는 opsForHash ( key 하나에 조회수, 관심수 필드 두개를 가진 지금 형태)를 사용하여 increment로 관리하고 싶어서 사용하지 않았습니다.

적절한 예시인지 모르겠지만 동시성 문제 14분부터 보시면 참고 될 것 같아요!
https://www.youtube.com/watch?v=mPB2CZiAkKM&t=1042s&ab_channel=%EC%9A%B0%EC%95%84%ED%95%9C%ED%85%8C%ED%81%AC

## ✔️ Completed Issue Number
close #95 
