### PR TITLE
[refactor] address, category, jwt 도메인 리팩토링

### DIFF
--- a/be/src/main/java/kr/codesquad/secondhand/api/address/controller/AddressController.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/address/controller/AddressController.java
@@ -1,7 +1,7 @@
 package kr.codesquad.secondhand.api.address.controller;
 
+import kr.codesquad.secondhand.api.address.dto.AddressSliceResponse;
 import kr.codesquad.secondhand.api.address.service.AddressService;
-import kr.codesquad.secondhand.api.member.dto.response.AddressSliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/be/src/main/java/kr/codesquad/secondhand/api/address/dto/AddressSliceResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/address/dto/AddressSliceResponse.java
@@ -1,4 +1,4 @@
-package kr.codesquad.secondhand.api.member.dto.response;
+package kr.codesquad.secondhand.api.address.dto;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,15 +11,16 @@ public class AddressSliceResponse {
     private final List<AddressesResponse> addresses;
     private final Boolean hasNext;
 
-    public AddressSliceResponse(List<AddressesResponse> addresses, Boolean hasNext) {
+    private AddressSliceResponse(List<AddressesResponse> addresses, Boolean hasNext) {
         this.addresses = addresses;
         this.hasNext = hasNext;
     }
 
     public static AddressSliceResponse of(List<Address> addresses, Boolean hasNext) {
-        return new AddressSliceResponse(addresses.stream()
+        List<AddressesResponse> addressesResponses = addresses.stream()
                 .map(AddressesResponse::from)
-                .collect(Collectors.toUnmodifiableList()), hasNext);
+                .collect(Collectors.toUnmodifiableList());
+        return new AddressSliceResponse(addressesResponses, hasNext);
     }
 
     @Getter

--- a/be/src/main/java/kr/codesquad/secondhand/api/address/service/AddressService.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/address/service/AddressService.java
@@ -2,8 +2,8 @@ package kr.codesquad.secondhand.api.address.service;
 
 import java.util.List;
 import kr.codesquad.secondhand.api.address.domain.Address;
+import kr.codesquad.secondhand.api.address.dto.AddressSliceResponse;
 import kr.codesquad.secondhand.api.address.repository.AddressRepositoryImpl;
-import kr.codesquad.secondhand.api.member.dto.response.AddressSliceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/dto/CategoryReadResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/dto/CategoryReadResponse.java
@@ -3,6 +3,7 @@ package kr.codesquad.secondhand.api.category.dto;
 import java.util.List;
 import java.util.stream.Collectors;
 import kr.codesquad.secondhand.api.category.domain.Category;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -12,7 +13,8 @@ public class CategoryReadResponse {
     private final String name;
     private final String imgUrl;
 
-    public CategoryReadResponse(Long id, String name, String imgUrl) {
+    @Builder
+    private CategoryReadResponse(Long id, String name, String imgUrl) {
         this.id = id;
         this.name = name;
         this.imgUrl = imgUrl;

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/dto/CategoryReadResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/dto/CategoryReadResponse.java
@@ -21,12 +21,20 @@ public class CategoryReadResponse {
     }
 
     public static CategoryReadResponse from(Category category) {
-        return new CategoryReadResponse(category.getId(), category.getName(), category.getImgUrl());
+        return CategoryReadResponse.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .imgUrl(category.getImgUrl())
+                .build();
     }
 
     public static List<CategoryReadResponse> from(List<Category> categories) {
         return categories.stream()
-                .map(category -> new CategoryReadResponse(category.getId(), category.getName(), category.getImgUrl()))
+                .map(category -> CategoryReadResponse.builder()
+                        .id(category.getId())
+                        .name(category.getName())
+                        .imgUrl(category.getImgUrl())
+                        .build())
                 .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/dto/CategorySummaryResponse.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/dto/CategorySummaryResponse.java
@@ -5,6 +5,9 @@ import java.util.stream.Collectors;
 import kr.codesquad.secondhand.api.category.domain.Category;
 import lombok.Getter;
 
+/**
+ * 상품 상세 조회, 관심 상품 목록 조회에서 공통으로 사용
+ */
 @Getter
 public class CategorySummaryResponse {
 

--- a/be/src/main/java/kr/codesquad/secondhand/api/category/exception/CategoryException.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/category/exception/CategoryException.java
@@ -4,6 +4,12 @@ import kr.codesquad.secondhand.global.exception.CustomRuntimeException;
 
 public class CategoryException extends CustomRuntimeException {
 
+    private static final String ERROR_MESSAGE = "카테고리 관련 오류입니다.";
+
+    public CategoryException() {
+        super(ERROR_MESSAGE);
+    }
+
     public CategoryException(String message) {
         super(message);
     }

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/Jwt.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/Jwt.java
@@ -1,13 +1,15 @@
 package kr.codesquad.secondhand.api.jwt.domain;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class Jwt {
 
-    private String accessToken;
-    private String refreshToken;
+    private final String accessToken;
+    private final String refreshToken;
 
+    public Jwt(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
 }

--- a/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/MemberRefreshToken.java
+++ b/be/src/main/java/kr/codesquad/secondhand/api/jwt/domain/MemberRefreshToken.java
@@ -5,14 +5,12 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "token")
 public class MemberRefreshToken {
 
@@ -20,6 +18,11 @@ public class MemberRefreshToken {
     private Long memberId;
 
     private String refreshToken;
+
+    public MemberRefreshToken(Long memberId, String refreshToken) {
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+    }
 
     public boolean matches(String refreshToken) {
         return Objects.equals(this.refreshToken, refreshToken);


### PR DESCRIPTION
## 🔑 Key changes
- #108 
- `Address Dto` 디렉토리를 `Member` 하위에서 `Address` 도메인 하위로 이동
  - 이유: 동네 목록 조회 시 응답 Dto는 Member가 아닌 Address 도메인이기 때문
- `CategoryReadResponse`의 생성자 접근 제어자를 `private`으로 수정
  - 이유: 내부 `from` 메서드에서만 사용되기 때문
  - `private`으로 변경 후 내부 로직을 `builder` 패턴으로 변경
  - 이유: name/url 이 모두 String 타입인데 개발자 실수로 순서가 바뀌었을 때 실수를 알아차리기 쉽고 필드 순서가 변경되었을 때 오류 방지를 위함
- 도메인에서 `@AllArgsConstructor` 어노테이션 제거 
  - Lombok 사용 시 주의사항: https://siahn95.tistory.com/170

## 👋 To reviewers
자잘한 사항들 수정했어요.!

## ✔️ Completed Issue Number
close #108 
